### PR TITLE
Include dash in shell completion search pattern

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -57,13 +57,13 @@ class <%= klass %> < Formula
 
     completion_for_bash = Dir[
                             "#{brew_gem_prefix}/completion{s,}/<%= name %>.{bash,sh}",
-                            "#{brew_gem_prefix}/**/<%= name %>_completion{s,}.{bash,sh}"
+                            "#{brew_gem_prefix}/**/<%= name %>{_,-}completion{s,}.{bash,sh}"
                           ].first
     bash_completion.install completion_for_bash if completion_for_bash
 
     completion_for_zsh = Dir[
                            "#{brew_gem_prefix}/completions/<%= name %>.zsh",
-                           "#{brew_gem_prefix}/**/<%= name %>_completion{s,}.zsh"
+                           "#{brew_gem_prefix}/**/<%= name %>{_,-}completion{s,}.zsh"
                          ].first
     zsh_completion.install completion_for_zsh if completion_for_zsh
 


### PR DESCRIPTION
Would match projects[1] that use `cmd-completion.sh` instead of `cmd_completion.sh`

[1] https://github.com/sferik/t/blob/master/etc/t-completion.sh